### PR TITLE
api 하나로 변경

### DIFF
--- a/api/news.js
+++ b/api/news.js
@@ -1,37 +1,14 @@
 import {
   article_url,
-  category,
   country_code,
   __api_key,
 } from "../config/rest_config";
 import axios from "axios";
 
-export const getArticles = async () => {
+export const getArticles = async (category) => {
   try {
     const articles = await axios.get(
       `${article_url}?country=${country_code}&category=${category}&apiKey=${__api_key}`
-    );
-    return articles.data.articles;
-  } catch (error) {
-    throw error;
-  }
-};
-
-export const getHealth = async () => {
-  try {
-    const articles = await axios.get(
-      `${article_url}?country=${country_code}&category=health&apiKey=${__api_key}`
-    );
-    return articles.data.articles;
-  } catch (error) {
-    throw error;
-  }
-};
-
-export const getEntertainment = async () => {
-  try {
-    const articles = await axios.get(
-      `${article_url}?country=${country_code}&category=entertainment&apiKey=${__api_key}`
     );
     return articles.data.articles;
   } catch (error) {

--- a/components/Tabs/TabThree.js
+++ b/components/Tabs/TabThree.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { getEntertainment } from "../../api/news";
+import { getArticles } from "../../api/news";
 import { View, Text, ActivityIndicator } from "react-native";
 import { Container, Content, List } from "native-base";
 import DataItem from "../DataItem";
@@ -13,7 +13,7 @@ export default function TabThree() {
 
   useEffect(() => {
     const get_data = async () => {
-      setArticles(await getEntertainment());
+      setArticles(await getArticles('entertainment'));
       setIsLoading(false);
     };
     get_data();

--- a/components/Tabs/TabTwo.js
+++ b/components/Tabs/TabTwo.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { getHealth } from "../../api/news";
+import { getArticles } from "../../api/news";
 import { View, Text, ActivityIndicator } from "react-native";
 import { Container, Content, List } from "native-base";
 import DataItem from "../DataItem";
@@ -12,11 +12,11 @@ export default function TabTwo() {
   const [modalArticleData, setModalArticleData] = useState({});
 
   useEffect(() => {
-    const get_Health = async () => {
-      setArticles(await getHealth());
+    const get_data = async () => {
+      setArticles(await getArticles('health'));
       setIsLoading(false);
     };
-    get_Health();
+    get_data();
   }, []);
 
   const viewModal = (articleData) => {

--- a/components/Tabs/TapOne.js
+++ b/components/Tabs/TapOne.js
@@ -13,7 +13,7 @@ export default function TabOne() {
 
   useEffect(() => {
     async function get_articles() {
-      setArticles(await getArticles());
+      setArticles(await getArticles('general'));
       setIsLoading(false);
     }
     get_articles();


### PR DESCRIPTION
 - 동일한 api 인데 여러버 호출하지말고 category 를 인자로 받아서 처리하는게 더 깔끔해.